### PR TITLE
Bump requirements of pyW800rf32 to version 3 and update codeowner

### DIFF
--- a/homeassistant/components/w800rf32/manifest.json
+++ b/homeassistant/components/w800rf32/manifest.json
@@ -3,8 +3,8 @@
   "name": "W800rf32",
   "documentation": "https://www.home-assistant.io/components/w800rf32",
   "requirements": [
-    "pyW800rf32==0.1"
+    "pyW800rf32==0.3"
   ],
   "dependencies": [],
-  "codeowners": []
+  "codeowners": ["@horga83"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1029,7 +1029,7 @@ pyTibber==0.11.6
 pyW215==0.6.0
 
 # homeassistant.components.w800rf32
-pyW800rf32==0.1
+pyW800rf32==0.3
 
 # homeassistant.components.nextbus
 py_nextbus==0.1.2


### PR DESCRIPTION
## Description:
Bump requirements of pyW800rf32 to version 0.3 and update codeowner for W800rf32 component.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
